### PR TITLE
[BUGFIX] ovf file has to called box.ovf

### DIFF
--- a/lib/vagrant-export/exporter.rb
+++ b/lib/vagrant-export/exporter.rb
@@ -161,7 +161,7 @@ module VagrantPlugins
 
         else
 
-          ovf_file = File.join(exported_path, @vm.box.name.gsub(/[^a-zA-Z0-9]+/, '_')) + '.ovf'
+          ovf_file = File.join(exported_path, 'box.ovf')
           vm_id = @vm.id.to_s
 
           opts = {}


### PR DESCRIPTION
In order for the ovf file to be
recognized during vagrant import
it currently has to be called
box.ovf (up to vagrant v1.7.2)
